### PR TITLE
Allow to define custom services

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,23 @@ splitter deploy -f path/to/aab -n design-review
 
 ## Install
 
-Download the latest binary from GitHub Release.
+Please download the latest binary from GitHub Release. The following code may be useful.
+
+```shell
+version=<latest version>
+
+# for windows
+curl -sL -o "splitter.zip" \
+    "https://github.com/jmatsu/splitter/releases/download/$version/splitter_$(uname -s)_$(uname -m).zip"
+unzip splitter.zip
+./spliter -h
+
+# for linux or macOS
+curl -sL -o "splitter.tar" \
+    "https://github.com/jmatsu/splitter/releases/download/$version/splitter_$(uname -s)_$(uname -m).tar.gz"
+tar -xf splitter.tar
+./spliter -h
+```
 
 ## Configuration-based deployment
 
@@ -34,6 +50,8 @@ OPTIONS:
 ```
 
 ### Syntax
+
+Please check [splitter.document.yml](splitter.document.yml) and [examples/splitter.yml](examples/splitter.yml) as well.
 
 ### DeployGate configuration
 
@@ -60,6 +78,14 @@ https://github.com/jmatsu/splitter/blob/main/internal/config/firebase_app_distri
 - `destination-path`
 
 https://github.com/jmatsu/splitter/blob/main/internal/config/local_config.go
+
+#### Custom service configuration
+
+**Required**
+
+- `auth-token`
+
+https://github.com/jmatsu/splitter/blob/main/internal/config/custom_service_config.go
 
 ### Pre-/Post-Steps
 
@@ -129,6 +155,23 @@ OPTIONS:
    --delete-source                     Specify true if you would not like to keep the source file. (default: false)
    --overwrite                         Specify true if you allow to overwrite the existing destination file. (default: false)
    --file-mode value                   The final file permission of the destination path. (default: Same to the source)
+```
+
+### Custom Service
+
+`service` command does this. You can distribute your apps to the defined service in the config file.
+
+```text
+USAGE:
+   splitter service [command options] [arguments...]
+
+OPTIONS:
+   --source-path value, -f value                A path to an app file.
+   --auth-token value, -t value                 The auth token to use for this distribution.
+   --name value, -n value                       A service name in the config file.
+   --header value [ --header value ]            Append <key>=<value> to headers
+   --query-param value [ --query-param value ]  Append <key>=<value> to query parameters
+   --form-param value [ --form-param value ]    Append <key>=<value> to form parameters
 ```
 
 ## About the supported services 

--- a/command/deploy.go
+++ b/command/deploy.go
@@ -62,11 +62,13 @@ func Deploy(name string, aliases []string) *cli.Command {
 				case config.DeploygateService:
 					dg := d.ServiceConfig.(config.DeployGateConfig)
 
-					return task.DeployToDeployGate(context.Context, dg, sourceFilePath, func(req *service.DeployGateDeployRequest) {
+					return task.DeployToDeployGate(context.Context, dg, sourceFilePath, func(req *service.DeployGateDeployRequest) error {
 						if v := context.String("release-note"); context.IsSet("release-note") {
 							req.SetMessage(v)
 							req.SetDistributionReleaseNote(v)
 						}
+
+						return nil
 					})
 				case config.LocalService:
 					lo := d.ServiceConfig.(config.LocalConfig)
@@ -75,10 +77,12 @@ func Deploy(name string, aliases []string) *cli.Command {
 				case config.FirebaseAppDistributionService:
 					fad := d.ServiceConfig.(config.FirebaseAppDistributionConfig)
 
-					return task.DeployToFirebaseAppDistribution(context.Context, fad, sourceFilePath, func(req *service.FirebaseAppDistributionDeployRequest) {
+					return task.DeployToFirebaseAppDistribution(context.Context, fad, sourceFilePath, func(req *service.FirebaseAppDistributionDeployRequest) error {
 						if v := context.String("release-note"); context.IsSet("release-note") {
 							req.SetReleaseNote(v)
 						}
+
+						return nil
 					})
 				default:
 					return errors.New(fmt.Sprintf("%s is not implemented yet", d.ServiceName))

--- a/command/deploy.go
+++ b/command/deploy.go
@@ -53,29 +53,29 @@ func Deploy(name string, aliases []string) *cli.Command {
 				return err
 			}
 
-			executor := task.NewExecutor(nil, context.Context, d.Lifecycle)
+			executor := task.NewExecutor(nil, context.Context, &d.Lifecycle)
 
 			return executor.Execute(func() error {
 				sourceFilePath := context.String("source-path")
 
 				switch d.ServiceName {
 				case config.DeploygateService:
-					dg := d.ServiceConfig.(*config.DeployGateConfig)
+					dg := d.ServiceConfig.(config.DeployGateConfig)
 
-					return task.DeployToDeployGate(context.Context, *dg, sourceFilePath, func(req *service.DeployGateDeployRequest) {
+					return task.DeployToDeployGate(context.Context, dg, sourceFilePath, func(req *service.DeployGateDeployRequest) {
 						if v := context.String("release-note"); context.IsSet("release-note") {
 							req.SetMessage(v)
 							req.SetDistributionReleaseNote(v)
 						}
 					})
 				case config.LocalService:
-					lo := d.ServiceConfig.(*config.LocalConfig)
+					lo := d.ServiceConfig.(config.LocalConfig)
 
-					return task.DeployToLocal(context.Context, *lo, sourceFilePath)
+					return task.DeployToLocal(context.Context, lo, sourceFilePath)
 				case config.FirebaseAppDistributionService:
-					fad := d.ServiceConfig.(*config.FirebaseAppDistributionConfig)
+					fad := d.ServiceConfig.(config.FirebaseAppDistributionConfig)
 
-					return task.DeployToFirebaseAppDistribution(context.Context, *fad, sourceFilePath, func(req *service.FirebaseAppDistributionDeployRequest) {
+					return task.DeployToFirebaseAppDistribution(context.Context, fad, sourceFilePath, func(req *service.FirebaseAppDistributionDeployRequest) {
 						if v := context.String("release-note"); context.IsSet("release-note") {
 							req.SetReleaseNote(v)
 						}

--- a/command/deploygate.go
+++ b/command/deploygate.go
@@ -77,7 +77,7 @@ func DeployGate(name string, aliases []string) *cli.Command {
 				ApiToken:     context.String("api-token"),
 			}
 
-			return task.DeployToDeployGate(context.Context, conf, context.String("source-path"), func(req *service.DeployGateDeployRequest) {
+			return task.DeployToDeployGate(context.Context, conf, context.String("source-path"), func(req *service.DeployGateDeployRequest) error {
 				if v := context.String("message"); context.IsSet("message") {
 					req.SetMessage(v)
 				}
@@ -95,6 +95,8 @@ func DeployGate(name string, aliases []string) *cli.Command {
 				}
 
 				req.SetIOSDisableNotification(context.Bool("disable-ios-notification"))
+
+				return nil
 			})
 		},
 	}

--- a/command/firebase_app_distribution.go
+++ b/command/firebase_app_distribution.go
@@ -72,7 +72,7 @@ func FirebaseAppDistribution(name string, aliases []string) *cli.Command {
 				conf.GroupAliases = v
 			}
 
-			return task.DeployToFirebaseAppDistribution(context.Context, conf, context.String("source-path"), func(req *service.FirebaseAppDistributionDeployRequest) {
+			return task.DeployToFirebaseAppDistribution(context.Context, conf, context.String("source-path"), func(req *service.FirebaseAppDistributionDeployRequest) error {
 				if v := context.String("release-note"); context.IsSet("release-note") {
 					req.SetReleaseNote(v)
 				}
@@ -80,6 +80,8 @@ func FirebaseAppDistribution(name string, aliases []string) *cli.Command {
 				if v := strings.Split(context.String("tester-emails"), ","); context.IsSet("tester-emails") && len(v) > 0 {
 					req.SetTesterEmails(v)
 				}
+
+				return nil
 			})
 		},
 	}

--- a/command/service.go
+++ b/command/service.go
@@ -1,0 +1,90 @@
+package command
+
+import (
+	"github.com/jmatsu/splitter/internal/config"
+	"github.com/jmatsu/splitter/service"
+	"github.com/jmatsu/splitter/task"
+	"github.com/pkg/errors"
+	"github.com/urfave/cli/v2"
+	"strings"
+)
+
+// CustomService command distributes your app to the defined service in the config file.
+func CustomService(name string, aliases []string) *cli.Command {
+	return &cli.Command{
+		Name:        name,
+		Aliases:     aliases,
+		Usage:       "Deploy your apps to the defined service in the config file.",
+		Description: "You can distribute your apps to the defined service in the config file.",
+		Flags: []cli.Flag{
+			&cli.PathFlag{
+				Name: "source-path",
+				Aliases: []string{
+					"f",
+				},
+				Usage:    "A path to an app file.",
+				Required: true,
+			},
+			&cli.StringFlag{
+				Name: "auth-token",
+				Aliases: []string{
+					"t",
+				},
+				Usage:    "The auth token to use for this distribution.",
+				Required: true,
+			},
+			&cli.StringFlag{
+				Name:     "name",
+				Usage:    "A service name in the config file.",
+				Required: true,
+			},
+			&cli.StringSliceFlag{
+				Name:     "header",
+				Usage:    "Append <key>=<value> to headers",
+				Required: false,
+			},
+			&cli.StringSliceFlag{
+				Name:     "query-param",
+				Usage:    "Append <key>=<value> to query parameters",
+				Required: false,
+			},
+			&cli.StringSliceFlag{
+				Name:     "form-param",
+				Usage:    "Append <key>=<value> to form parameters",
+				Required: false,
+			},
+		},
+		Action: func(context *cli.Context) error {
+			conf := config.CustomServiceConfig{
+				AuthToken: context.String("auth-token"),
+			}
+
+			def, err := config.CurrentConfig().Definition(context.String("name"))
+
+			if err != nil {
+				return errors.Wrapf(err, "cannot get a definition")
+			}
+
+			return task.DeployToCustomService(context.Context, def, conf, context.String("source-path"), func(req *service.CustomServiceDeployRequest) {
+				if headers := context.StringSlice("header"); context.IsSet("header") {
+					for _, header := range headers {
+						name, value, _ := strings.Cut(header, "=")
+						req.SetHeader(name, value)
+					}
+				}
+				if params := context.StringSlice("query-param"); context.IsSet("query-param") {
+					for _, param := range params {
+						name, value, _ := strings.Cut(param, "=")
+						req.SetQueryParam(name, value)
+					}
+				}
+				if params := context.StringSlice("form-param"); context.IsSet("form-param") {
+					for _, param := range params {
+						name, value, _ := strings.Cut(param, "=")
+						req.SetFormParam(name, value)
+					}
+				}
+			})
+		},
+	}
+}

--- a/command/service.go
+++ b/command/service.go
@@ -75,7 +75,11 @@ func CustomService(name string, aliases []string) *cli.Command {
 				if params := context.StringSlice("query-param"); context.IsSet("query-param") {
 					for _, param := range params {
 						name, value, _ := strings.Cut(param, "=")
-						req.SetQueryParam(name, value)
+						if req.HasQueryParam(name) {
+							req.AddQueryParam(name, value)
+						} else {
+							req.SetQueryParam(name, value)
+						}
 					}
 				}
 				if params := context.StringSlice("form-param"); context.IsSet("form-param") {

--- a/examples/splitter.yml
+++ b/examples/splitter.yml
@@ -22,3 +22,14 @@ deployments:
     delete-source: false
     post-steps:
       - ['./notify-to-slack', '--text', 'We put a new apk to the shared drive.', '--channel', 'Cxyz123']
+
+services:
+  localhost:
+    endpoint: "http://localhost:3000/users/developer/apps"
+    source-file-format: "form_params.file"
+    auth:
+      style-format: "headers.Authorization"
+      value-format: "Bearer %s"
+    default:
+      form-params:
+        message: "splitter test"

--- a/internal/config/custom_service_config.go
+++ b/internal/config/custom_service_config.go
@@ -4,7 +4,7 @@ type CustomServiceConfig struct {
 	serviceNameHolder `yaml:",inline"`
 	ExecutionConfig   `yaml:",inline"`
 
-	AuthToken string `yaml:"auth-token"`
+	AuthToken string `yaml:"auth-token" required:"true"`
 }
 
 func (c *CustomServiceConfig) Validate() error {

--- a/internal/config/custom_service_config.go
+++ b/internal/config/custom_service_config.go
@@ -1,0 +1,12 @@
+package config
+
+type CustomServiceConfig struct {
+	serviceNameHolder `yaml:",inline"`
+	ExecutionConfig   `yaml:",inline"`
+
+	AuthToken string `yaml:"auth-token"`
+}
+
+func (c *CustomServiceConfig) Validate() error {
+	return validateMissingValues(c)
+}

--- a/internal/config/custom_service_config_test.go
+++ b/internal/config/custom_service_config_test.go
@@ -1,0 +1,36 @@
+package config
+
+import "testing"
+
+func Test_CustomServiceConfig_validateMissingValues(t *testing.T) {
+	t.Parallel()
+
+	sampleValue1 := "Sample1"
+
+	cases := map[string]struct {
+		config            CustomServiceConfig
+		expectedValidness bool
+	}{
+		"fully-filled": {
+			config: CustomServiceConfig{
+				AuthToken: sampleValue1,
+			},
+			expectedValidness: true,
+		},
+		"zero": {
+			config:            CustomServiceConfig{},
+			expectedValidness: false,
+		},
+	}
+
+	for name, c := range cases {
+		name, c := name, c
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			if err := validateMissingValues(&c.config); (err == nil) != c.expectedValidness {
+				t.Errorf("%s case is expected to be %t but %t", name, c.expectedValidness, err == nil)
+			}
+		})
+	}
+}

--- a/internal/config/custom_service_definition.go
+++ b/internal/config/custom_service_definition.go
@@ -15,13 +15,13 @@ const (
 	RequestBodyAssignFormat      valueAssignFormat = "request_body"
 	FormParamsAssignFormatPrefix valueAssignFormat = "form_params."
 	HeadersAssignFormatPrefix    valueAssignFormat = "headers."
-	QueryAssignFormatPrefix      valueAssignFormat = "query."
+	QueryAssignFormatPrefix      valueAssignFormat = "query_params."
 )
 
 type CustomServiceDefinition struct {
-	Endpoint                 string                   `yaml:"endpoint"`
-	SourceFileFormat         valueAssignFormat        `yaml:"source-file-format"`
-	AuthDefinition           CustomAuthDefinition     `yaml:"auth"`
+	Endpoint                 string                   `yaml:"endpoint" required:"true"`
+	SourceFileFormat         valueAssignFormat        `yaml:"source-file-format" required:"true"`
+	AuthDefinition           CustomAuthDefinition     `yaml:"auth" required:"true"`
 	DefaultRequestDefinition DefaultRequestDefinition `yaml:"default,omitempty"`
 }
 
@@ -117,9 +117,9 @@ func (d *CustomAuthDefinition) AuthValue() (string, string, error) {
 }
 
 type DefaultRequestDefinition struct {
-	Headers    map[string]string `yaml:"headers,omitempty"`
-	Query      map[string]string `yaml:"query,omitempty"`
-	FormParams map[string]string `yaml:"form-params,omitempty"`
+	Headers    map[string]string   `yaml:"headers,omitempty"`
+	Queries    map[string][]string `yaml:"queries,omitempty"`
+	FormParams map[string]string   `yaml:"form-params,omitempty"`
 }
 
 func (d *DefaultRequestDefinition) validate() error {
@@ -127,7 +127,7 @@ func (d *DefaultRequestDefinition) validate() error {
 		return errors.New("headers has at least one empty key")
 	}
 
-	if slices.Contains(maps.Keys(d.Query), "") {
+	if slices.Contains(maps.Keys(d.Queries), "") {
 		return errors.New("query has at least one empty key")
 	}
 

--- a/internal/config/custom_service_definition.go
+++ b/internal/config/custom_service_definition.go
@@ -49,6 +49,14 @@ func (d *CustomServiceDefinition) validate() error {
 		}
 	}
 
+	if err := d.AuthDefinition.validate(); err != nil {
+		return err
+	}
+
+	if err := d.DefaultRequestDefinition.validate(); err != nil {
+		return err
+	}
+
 	return nil
 }
 
@@ -69,8 +77,8 @@ func (d *CustomServiceDefinition) SourceFile() (string, string, error) {
 }
 
 type CustomAuthDefinition struct {
-	StyleFormat valueAssignFormat `yaml:"style-format"`
-	ValueFormat string            `yaml:"value-format"`
+	StyleFormat valueAssignFormat `yaml:"style-format" required:"true"`
+	ValueFormat string            `yaml:"value-format" required:"true"`
 }
 
 func (d *CustomAuthDefinition) validate() error {

--- a/internal/config/custom_service_definition.go
+++ b/internal/config/custom_service_definition.go
@@ -1,0 +1,95 @@
+package config
+
+import (
+	"fmt"
+	"github.com/pkg/errors"
+	"golang.org/x/exp/maps"
+	"golang.org/x/exp/slices"
+	"strings"
+)
+
+type valueAssignFormat = string
+
+const (
+	requestBodyAssignFormat      valueAssignFormat = "request_body"
+	formParamsAssignFormatPrefix valueAssignFormat = "form_params."
+	headersAssignFormatPrefix    valueAssignFormat = "headers."
+	queryAssignFormatPrefix      valueAssignFormat = "query."
+)
+
+type CustomServiceDefinition struct {
+	Endpoint                 string                   `yaml:"endpoint"`
+	SourceFileFormat         valueAssignFormat        `yaml:"source-file-format"`
+	AuthDefinition           CustomAuthDefinition     `yaml:"auth"`
+	DefaultRequestDefinition DefaultRequestDefinition `yaml:"default,omitempty"`
+}
+
+func (d *CustomServiceDefinition) validate() error {
+
+	if d.SourceFileFormat != requestBodyAssignFormat {
+		var valid bool
+
+		for _, prefix := range []string{formParamsAssignFormatPrefix, queryAssignFormatPrefix} {
+			if !strings.HasPrefix(d.SourceFileFormat, prefix) {
+				valid = false
+				break
+			}
+		}
+
+		if !valid {
+			return errors.New(fmt.Sprintf("%s does not follow the correct format", d.SourceFileFormat))
+		}
+	}
+
+	return nil
+}
+
+type CustomAuthDefinition struct {
+	StyleFormat valueAssignFormat `yaml:"style-format"`
+	ValueFormat string            `yaml:"value-format"`
+}
+
+func (d *CustomAuthDefinition) validate() error {
+	var valid bool
+
+	for _, prefix := range []string{formParamsAssignFormatPrefix, headersAssignFormatPrefix, queryAssignFormatPrefix} {
+		if !strings.HasPrefix(d.StyleFormat, prefix) {
+			valid = false
+			break
+		}
+	}
+
+	if !valid {
+		return errors.New(fmt.Sprintf("%s does not follow the correct format", d.StyleFormat))
+	}
+
+	if n := len(strings.SplitN(d.ValueFormat, "%s", 3)); n > 1 {
+		return errors.New(fmt.Sprintf("%s contains 2 or more %%s", d.StyleFormat))
+	} else if n == 0 {
+		return errors.New(fmt.Sprintf("%s must contain %%s", d.StyleFormat))
+	}
+
+	return nil
+}
+
+type DefaultRequestDefinition struct {
+	Headers    map[string]string `yaml:"headers,omitempty"`
+	Query      map[string]string `yaml:"query,omitempty"`
+	FormParams map[string]string `yaml:"form-params,omitempty"`
+}
+
+func (d *DefaultRequestDefinition) validate() error {
+	if slices.Contains(maps.Keys(d.Headers), "") {
+		return errors.New("headers has at least one empty key")
+	}
+
+	if slices.Contains(maps.Keys(d.Query), "") {
+		return errors.New("query has at least one empty key")
+	}
+
+	if slices.Contains(maps.Keys(d.FormParams), "") {
+		return errors.New("form-params has at least one empty key")
+	}
+
+	return nil
+}

--- a/internal/config/custom_service_definition_test.go
+++ b/internal/config/custom_service_definition_test.go
@@ -1,0 +1,214 @@
+package config
+
+import "testing"
+
+func Test_CustomAuthDefinition_validate(t *testing.T) {
+	t.Parallel()
+
+	cases := map[string]struct {
+		definition        CustomAuthDefinition
+		expectedValidness bool
+	}{
+		"header token": {
+			definition: CustomAuthDefinition{
+				StyleFormat: HeadersAssignFormatPrefix + "test",
+				ValueFormat: "%s",
+			},
+			expectedValidness: false,
+		},
+		"query token": {
+			definition: CustomAuthDefinition{
+				StyleFormat: QueryAssignFormatPrefix + "test",
+				ValueFormat: "%s",
+			},
+			expectedValidness: false,
+		},
+		"form token": {
+			definition: CustomAuthDefinition{
+				StyleFormat: FormParamsAssignFormatPrefix + "test",
+				ValueFormat: "%s",
+			},
+			expectedValidness: false,
+		},
+		"style format is a prefix only": {
+			definition: CustomAuthDefinition{
+				StyleFormat: FormParamsAssignFormatPrefix,
+				ValueFormat: "%s",
+			},
+			expectedValidness: false,
+		},
+		"unknown style format": {
+			definition: CustomAuthDefinition{
+				StyleFormat: "obababa",
+				ValueFormat: "%s",
+			},
+			expectedValidness: false,
+		},
+		"too many %s in value format": {
+			definition: CustomAuthDefinition{
+				StyleFormat: FormParamsAssignFormatPrefix + "test",
+				ValueFormat: "%s %s",
+			},
+			expectedValidness: false,
+		},
+		"missing %s in value format": {
+			definition: CustomAuthDefinition{
+				StyleFormat: FormParamsAssignFormatPrefix + "test",
+				ValueFormat: "hello",
+			},
+			expectedValidness: false,
+		},
+		"zero": {definition: CustomAuthDefinition{}, expectedValidness: false},
+	}
+
+	for name, c := range cases {
+		name, c := name, c
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			if err := c.definition.validate(); (err == nil) != c.expectedValidness {
+				t.Errorf("%s case is expected to be %t but %t", name, c.expectedValidness, err == nil)
+			}
+		})
+	}
+}
+
+func Test_CustomAuthDefinition_AuthType(t *testing.T) {
+	t.Parallel()
+
+	cases := map[string]struct {
+		definition     CustomAuthDefinition
+		expectedPrefix string
+		expectedValue  string
+	}{
+		"header token": {
+			definition: CustomAuthDefinition{
+				StyleFormat: HeadersAssignFormatPrefix + "test",
+				ValueFormat: "%s",
+			},
+			expectedPrefix: HeadersAssignFormatPrefix,
+			expectedValue:  "test",
+		},
+		"query token": {
+			definition: CustomAuthDefinition{
+				StyleFormat: QueryAssignFormatPrefix + "test",
+				ValueFormat: "%s",
+			},
+			expectedPrefix: QueryAssignFormatPrefix,
+			expectedValue:  "test",
+		},
+		"form token": {
+			definition: CustomAuthDefinition{
+				StyleFormat: FormParamsAssignFormatPrefix + "test",
+				ValueFormat: "%s",
+			},
+			expectedPrefix: FormParamsAssignFormatPrefix,
+			expectedValue:  "test",
+		},
+		"style format is a prefix only": {
+			definition: CustomAuthDefinition{
+				StyleFormat: FormParamsAssignFormatPrefix,
+				ValueFormat: "%s",
+			},
+		},
+		"unknown style format": {
+			definition: CustomAuthDefinition{
+				StyleFormat: "obababa",
+				ValueFormat: "%s",
+			},
+		},
+		"too many %s in value format": {
+			definition: CustomAuthDefinition{
+				StyleFormat: FormParamsAssignFormatPrefix + "test",
+				ValueFormat: "%s %s",
+			},
+		},
+		"missing %s in value format": {
+			definition: CustomAuthDefinition{
+				StyleFormat: FormParamsAssignFormatPrefix + "test",
+				ValueFormat: "hello",
+			},
+		},
+		"zero": {definition: CustomAuthDefinition{}},
+	}
+
+	for name, c := range cases {
+		name, c := name, c
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			if err := c.definition.validate(); err != nil {
+				return // expected or don't need to consider
+			} else if prefix, value, err := c.definition.AuthValue(); err != nil {
+				t.Fatalf("couldn't get a type from valid definition: %v", err)
+			} else if prefix != c.expectedPrefix || value != c.expectedValue {
+				t.Errorf("%s case is expected to be %s, %s but %s, %s", name, c.expectedPrefix, c.expectedValue, prefix, value)
+			}
+		})
+	}
+}
+
+func Test_DefaultRequestDefinition_validate(t *testing.T) {
+	t.Parallel()
+
+	cases := map[string]struct {
+		definition        DefaultRequestDefinition
+		expectedValidness bool
+	}{
+		"empty in queries": {
+			definition: DefaultRequestDefinition{
+				Queries: map[string][]string{
+					"key1": {},
+				},
+			},
+			expectedValidness: true,
+		},
+		"empty key in headers": {
+			definition: DefaultRequestDefinition{
+				Headers: map[string]string{
+					"": "value",
+				},
+			},
+			expectedValidness: false,
+		},
+		"empty key in queries": {
+			definition: DefaultRequestDefinition{
+				Queries: map[string][]string{
+					"": {"value"},
+				},
+			},
+			expectedValidness: false,
+		},
+		"empty key in form params": {
+			definition: DefaultRequestDefinition{
+				FormParams: map[string]string{
+					"": "value",
+				},
+			},
+			expectedValidness: false,
+		},
+		"empty structs": {
+			definition: DefaultRequestDefinition{
+				Headers:    map[string]string{},
+				Queries:    map[string][]string{},
+				FormParams: map[string]string{},
+			},
+			expectedValidness: true,
+		},
+		"zero": {
+			definition:        DefaultRequestDefinition{},
+			expectedValidness: true,
+		},
+	}
+
+	for name, c := range cases {
+		name, c := name, c
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			if err := c.definition.validate(); (err == nil) != c.expectedValidness {
+				t.Errorf("%s case is expected to be %t but %t", name, c.expectedValidness, err == nil)
+			}
+		})
+	}
+}

--- a/internal/config/evaluator.go
+++ b/internal/config/evaluator.go
@@ -1,0 +1,42 @@
+package config
+
+import (
+	"fmt"
+	"github.com/jmatsu/splitter/internal/logger"
+	"github.com/pkg/errors"
+	"os"
+	"reflect"
+	"strings"
+)
+
+// Evaluate the styled format for the embedded variables.
+func evaluateValues(v any) error {
+	vRef := reflect.ValueOf(v).Elem()
+
+	if vRef.Kind() != reflect.Struct {
+		return errors.New(fmt.Sprintf("%v is not a struct", v))
+	}
+
+	for i := 0; i < vRef.NumField(); i++ {
+		value := vRef.Field(i)
+		field := vRef.Type().Field(i)
+		tag := vRef.Type().Field(i).Tag
+
+		if _, found := tag.Lookup("yaml"); !found {
+			continue
+		}
+
+		if value.Kind() == reflect.String {
+			if prefix, format, ok := strings.Cut(value.String(), ":"); ok && prefix == "format" {
+				newValue := os.ExpandEnv(format)
+				value.SetString(newValue)
+
+				logger.Logger.Debug().Msgf("%s = %v: is evaluated", field.Name, newValue)
+			} else {
+				logger.Logger.Debug().Msgf("%s = %v: needn't be evaluated", field.Name, value)
+			}
+		}
+	}
+
+	return nil
+}

--- a/internal/config/global_config.go
+++ b/internal/config/global_config.go
@@ -331,6 +331,14 @@ func (c *GlobalConfig) Dump(path string) error {
 	return nil
 }
 
+func (c *GlobalConfig) Definition(name string) (CustomServiceDefinition, error) {
+	if s, ok := c.services[name]; ok {
+		return s, nil
+	} else {
+		return CustomServiceDefinition{}, errors.New(fmt.Sprintf("%s is not found in services", name))
+	}
+}
+
 func (c *GlobalConfig) Deployment(name string) (Deployment, error) {
 	if d, ok := c.deployments[name]; ok {
 		switch d.ServiceName {

--- a/internal/config/global_config.go
+++ b/internal/config/global_config.go
@@ -176,6 +176,8 @@ func (c *GlobalConfig) configure() error {
 			return errors.Wrapf(err, "cannot load %s service definition", name)
 		} else if err := yaml.Unmarshal(bytes, &definition); err != nil {
 			return errors.Wrapf(err, "cannot load %s service definition", name)
+		} else if err := definition.validate(); err != nil {
+			return errors.Wrapf(err, "%s service definition is invalid", name)
 		}
 
 		c.services[name] = definition

--- a/internal/config/global_config.go
+++ b/internal/config/global_config.go
@@ -141,6 +141,10 @@ func (c *GlobalConfig) configure() error {
 		c.deployments = map[string]Deployment{}
 	}
 
+	if c.services == nil {
+		c.services = map[string]CustomServiceDefinition{}
+	}
+
 	if c.rawConfig.FormatStyle == "" {
 		c.rawConfig.FormatStyle = DefaultFormat
 	}
@@ -356,6 +360,12 @@ func (c *GlobalConfig) Deployment(name string) (Deployment, error) {
 			}
 		case LocalService:
 			config := d.ServiceConfig.(*LocalConfig)
+
+			if err := evaluateAndValidate(config); err != nil {
+				return Deployment{}, err
+			}
+		default:
+			config := d.ServiceConfig.(*CustomServiceConfig)
 
 			if err := evaluateAndValidate(config); err != nil {
 				return Deployment{}, err

--- a/internal/config/global_config.go
+++ b/internal/config/global_config.go
@@ -27,7 +27,8 @@ const (
 
 	DefaultConfigName = "splitter.yml"
 
-	deploymentsKey = "deployments" // deployment definitions' key in the config file.
+	deploymentsKey        = "deployments" // deployment definitions' key in the config file.
+	serviceDefinitionsKey = "services"    // service definitions' key in the config file.
 
 	DeploygateService              = "deploygate"                // represents DeployGateConfig
 	LocalService                   = "local"                     // represents LocalConfig
@@ -41,11 +42,13 @@ func ToEnvName(name string) string {
 // GlobalConfig is a shared configuration in one command execution.
 type GlobalConfig struct {
 	rawConfig   rawConfig
-	deployments map[string]*Deployment
+	deployments map[string]Deployment
+	services    map[string]CustomServiceDefinition
 }
 
 type rawConfig struct {
 	Deployments    map[string]interface{} `yaml:"deployments"`
+	Services       map[string]interface{} `yaml:"services"`
 	FormatStyle    string                 `yaml:"format-style,omitempty"`
 	NetworkTimeout string                 `yaml:"network-timeout,omitempty"`
 	WaitTimeout    string                 `yaml:"wait-timeout,omitempty"`
@@ -55,7 +58,7 @@ type rawConfig struct {
 type Deployment struct {
 	ServiceName   string
 	ServiceConfig any // See serviceConfig interface
-	Lifecycle     *ExecutionConfig
+	Lifecycle     ExecutionConfig
 }
 
 type FormatStyle = string
@@ -120,6 +123,7 @@ func LoadGlobalConfig(path *string) error {
 
 	config.rawConfig = rawConfig{
 		Deployments:    viper.GetStringMap(deploymentsKey),
+		Services:       viper.GetStringMap(serviceDefinitionsKey),
 		FormatStyle:    viper.GetString("format-style"),
 		WaitTimeout:    viper.GetString("wait-timeout"),
 		NetworkTimeout: viper.GetString("network-timeout"),
@@ -134,7 +138,7 @@ func LoadGlobalConfig(path *string) error {
 
 func (c *GlobalConfig) configure() error {
 	if c.deployments == nil {
-		c.deployments = map[string]*Deployment{}
+		c.deployments = map[string]Deployment{}
 	}
 
 	if c.rawConfig.FormatStyle == "" {
@@ -149,8 +153,32 @@ func (c *GlobalConfig) configure() error {
 		c.rawConfig.WaitTimeout = DefaultWaitTimeout
 	}
 
+	for name, values := range c.rawConfig.Services {
+		logger.Logger.Debug().Msgf("Configuring the service of %s", name)
+
+		values, correct := values.(map[string]interface{})
+
+		if !correct {
+			return errors.New(fmt.Sprintf("%s must be Mapping", name))
+		}
+
+		if slices.Contains([]string{DeploygateService, FirebaseAppDistributionService, LocalService}, name) {
+			return errors.New(fmt.Sprintf("%s is a reserved name", name))
+		}
+
+		var definition CustomServiceDefinition
+
+		if bytes, err := yaml.Marshal(values); err != nil {
+			return errors.Wrapf(err, "cannot load %s service definition", name)
+		} else if err := yaml.Unmarshal(bytes, &definition); err != nil {
+			return errors.Wrapf(err, "cannot load %s service definition", name)
+		}
+
+		c.services[name] = definition
+	}
+
 	for name, values := range c.rawConfig.Deployments {
-		logger.Logger.Debug().Msgf("Configuring %s", name)
+		logger.Logger.Debug().Msgf("Configuring the deployment of %s", name)
 
 		values, correct := values.(map[string]interface{})
 
@@ -174,10 +202,10 @@ func (c *GlobalConfig) configure() error {
 				return errors.Wrapf(err, "cannot load %s config", name)
 			}
 
-			c.deployments[name] = &Deployment{
+			c.deployments[name] = Deployment{
 				ServiceName:   deploygate.Name,
-				ServiceConfig: &deploygate,
-				Lifecycle:     &deploygate.ExecutionConfig,
+				ServiceConfig: deploygate,
+				Lifecycle:     deploygate.ExecutionConfig,
 			}
 		case FirebaseAppDistributionService:
 			firebase := FirebaseAppDistributionConfig{}
@@ -186,10 +214,10 @@ func (c *GlobalConfig) configure() error {
 				return errors.Wrapf(err, "cannot load %s config", name)
 			}
 
-			c.deployments[name] = &Deployment{
+			c.deployments[name] = Deployment{
 				ServiceName:   firebase.Name,
-				ServiceConfig: &firebase,
-				Lifecycle:     &firebase.ExecutionConfig,
+				ServiceConfig: firebase,
+				Lifecycle:     firebase.ExecutionConfig,
 			}
 		case LocalService:
 			local := LocalConfig{}
@@ -198,13 +226,29 @@ func (c *GlobalConfig) configure() error {
 				return errors.Wrapf(err, "cannot load %s config", name)
 			}
 
-			c.deployments[name] = &Deployment{
+			c.deployments[name] = Deployment{
 				ServiceName:   local.Name,
-				ServiceConfig: &local,
-				Lifecycle:     &local.ExecutionConfig,
+				ServiceConfig: local,
+				Lifecycle:     local.ExecutionConfig,
 			}
 		default:
-			return errors.New(fmt.Sprintf("%s of %s is an unknown service", service.Name, name))
+			if _, ok := c.services[name]; ok {
+				logger.Logger.Debug().Msgf("%s is a custom service", name)
+
+				custom := CustomServiceConfig{}
+
+				if err := loadServiceConfig(&custom, values); err != nil {
+					return errors.Wrapf(err, "cannot load %s config", name)
+				}
+
+				c.deployments[name] = Deployment{
+					ServiceName:   name,
+					ServiceConfig: custom,
+					Lifecycle:     custom.ExecutionConfig,
+				}
+			} else {
+				return errors.New(fmt.Sprintf("%s of %s is an unknown service", service.Name, name))
+			}
 		}
 	}
 
@@ -287,40 +331,40 @@ func (c *GlobalConfig) Dump(path string) error {
 	return nil
 }
 
-func (c *GlobalConfig) Deployment(name string) (*Deployment, error) {
-	if d := c.deployments[name]; d != nil {
+func (c *GlobalConfig) Deployment(name string) (Deployment, error) {
+	if d, ok := c.deployments[name]; ok {
 		switch d.ServiceName {
 		case DeploygateService:
 			config := d.ServiceConfig.(*DeployGateConfig)
 
 			if err := evaluateAndValidate(config); err != nil {
-				return nil, err
+				return Deployment{}, err
 			}
 		case FirebaseAppDistributionService:
 			config := d.ServiceConfig.(*FirebaseAppDistributionConfig)
 
 			if err := evaluateAndValidate(config); err != nil {
-				return nil, err
+				return Deployment{}, err
 			}
 		case LocalService:
 			config := d.ServiceConfig.(*LocalConfig)
 
 			if err := evaluateAndValidate(config); err != nil {
-				return nil, err
+				return Deployment{}, err
 			}
 		}
 
 		return d, nil
 	} else {
-		return nil, errors.New(fmt.Sprintf("%s deployment is not found", name))
+		return Deployment{}, errors.New(fmt.Sprintf("%s deployment is not found", name))
 	}
 }
 
 func (c *GlobalConfig) AddDeployment(name string, serviceName string) error {
-	if d := c.deployments[name]; d != nil {
+	if d, ok := c.deployments[name]; ok {
 		return errors.New(fmt.Sprintf("%s (service = %s) already exists in the config.", name, d.ServiceName))
 	} else {
-		d = &Deployment{
+		d = Deployment{
 			ServiceName: serviceName,
 		}
 
@@ -362,4 +406,14 @@ func (c *GlobalConfig) AddDeployment(name string, serviceName string) error {
 
 		return c.configure()
 	}
+}
+
+func evaluateAndValidate(v any) error {
+	if err := evaluateValues(v); err != nil {
+		return err
+	} else if err := validateMissingValues(v); err != nil {
+		return err
+	}
+
+	return nil
 }

--- a/internal/config/global_config_test.go
+++ b/internal/config/global_config_test.go
@@ -67,7 +67,7 @@ func Test_Config_configure(t *testing.T) {
 					NetworkTimeout: DefaultNetworkTimeout,
 					WaitTimeout:    DefaultWaitTimeout,
 				},
-				deployments: map[string]*Deployment{
+				deployments: map[string]Deployment{
 					"def1": {
 						ServiceName: DeploygateService,
 						ServiceConfig: DeployGateConfig{
@@ -111,7 +111,7 @@ func Test_Config_configure(t *testing.T) {
 					NetworkTimeout: DefaultNetworkTimeout,
 					WaitTimeout:    DefaultWaitTimeout,
 				},
-				deployments: map[string]*Deployment{
+				deployments: map[string]Deployment{
 					"def1": {
 						ServiceName:   DeploygateService,
 						ServiceConfig: DeployGateConfig{},

--- a/internal/config/service_config.go
+++ b/internal/config/service_config.go
@@ -1,14 +1,8 @@
 package config
 
 import (
-	"fmt"
 	"github.com/caarlos0/env/v6"
-	"github.com/jmatsu/splitter/internal/logger"
-	"github.com/pkg/errors"
 	"gopkg.in/yaml.v3"
-	"os"
-	"reflect"
-	"strings"
 )
 
 type serviceNameHolder struct {
@@ -16,17 +10,7 @@ type serviceNameHolder struct {
 }
 
 type serviceConfig interface {
-	testConfig | DeployGateConfig | LocalConfig | FirebaseAppDistributionConfig
-}
-
-func evaluateAndValidate[T serviceConfig](v *T) error {
-	if err := evaluateValues(v); err != nil {
-		return err
-	} else if err := validateMissingValues(v); err != nil {
-		return err
-	}
-
-	return nil
+	testConfig | DeployGateConfig | LocalConfig | FirebaseAppDistributionConfig | CustomServiceConfig
 }
 
 // Set values to the config. Priority: Environment Variables > Given values
@@ -40,81 +24,4 @@ func loadServiceConfig[T serviceConfig](v *T, values map[string]interface{}) err
 	}
 
 	return nil
-}
-
-// Evaluate the styled format for the embedded variables.
-func evaluateValues[T serviceConfig](v *T) error {
-	vRef := reflect.ValueOf(v).Elem()
-
-	if vRef.Kind() != reflect.Struct {
-		return errors.New(fmt.Sprintf("%v is not a struct", v))
-	}
-
-	for i := 0; i < vRef.NumField(); i++ {
-		value := vRef.Field(i)
-		field := vRef.Type().Field(i)
-		tag := vRef.Type().Field(i).Tag
-
-		if _, found := tag.Lookup("yaml"); !found {
-			continue
-		}
-
-		if value.Kind() == reflect.String {
-			if prefix, format, ok := strings.Cut(value.String(), ":"); ok && prefix == "format" {
-				newValue := os.ExpandEnv(format)
-				value.SetString(newValue)
-
-				logger.Logger.Debug().Msgf("%s = %v: is evaluated", field.Name, newValue)
-			} else {
-				logger.Logger.Debug().Msgf("%s = %v: needn't be evaluated", field.Name, value)
-			}
-		}
-	}
-
-	return nil
-}
-
-// Collect errors via the reflection. Target fields must have yaml tag. Required fields must not be zero values.
-func validateMissingValues[T serviceConfig](v *T) error {
-	var missingKeys []string
-
-	vRef := reflect.ValueOf(v).Elem()
-
-	if vRef.Kind() != reflect.Struct {
-		return errors.New(fmt.Sprintf("%v is not a struct", v))
-	}
-
-	for i := 0; i < vRef.NumField(); i++ {
-		value := vRef.Field(i)
-		field := vRef.Type().Field(i)
-		tag := vRef.Type().Field(i).Tag
-
-		t, found := tag.Lookup("yaml")
-
-		if !found {
-			logger.Logger.Debug().Msgf("%v is ignored", field.Name)
-			continue
-		}
-
-		logger.Logger.Debug().Msgf("%s = %v: yaml:\"%s\"", field.Name, value, t)
-
-		key, _, _ := strings.Cut(t, ",")
-
-		if b, found := tag.Lookup("required"); found && b == "true" {
-			if value.IsZero() {
-				logger.Logger.Error().Msgf("%s is required but not assigned", key)
-				missingKeys = append(missingKeys, key)
-			} else {
-				logger.Logger.Debug().Msgf("%s is set", key)
-			}
-		} else {
-			logger.Logger.Debug().Msgf("%s is optional", key)
-		}
-	}
-
-	if num := len(missingKeys); num > 0 {
-		return errors.New(fmt.Sprintf("%d keys lacked or their values are empty: %s", num, strings.Join(missingKeys, ",")))
-	} else {
-		return nil
-	}
 }

--- a/internal/config/validation.go
+++ b/internal/config/validation.go
@@ -1,0 +1,54 @@
+package config
+
+import (
+	"fmt"
+	"github.com/jmatsu/splitter/internal/logger"
+	"github.com/pkg/errors"
+	"reflect"
+	"strings"
+)
+
+// Collect errors via the reflection. Target fields must have yaml tag. Required fields must not be zero values.
+func validateMissingValues(v any) error {
+	var missingKeys []string
+
+	vRef := reflect.ValueOf(v).Elem()
+
+	if vRef.Kind() != reflect.Struct {
+		return errors.New(fmt.Sprintf("%v is not a struct", v))
+	}
+
+	for i := 0; i < vRef.NumField(); i++ {
+		value := vRef.Field(i)
+		field := vRef.Type().Field(i)
+		tag := vRef.Type().Field(i).Tag
+
+		t, found := tag.Lookup("yaml")
+
+		if !found {
+			logger.Logger.Debug().Msgf("%v is ignored", field.Name)
+			continue
+		}
+
+		logger.Logger.Debug().Msgf("%s = %v: yaml:\"%s\"", field.Name, value, t)
+
+		key, _, _ := strings.Cut(t, ",")
+
+		if b, found := tag.Lookup("required"); found && b == "true" {
+			if value.IsZero() {
+				logger.Logger.Error().Msgf("%s is required but not assigned", key)
+				missingKeys = append(missingKeys, key)
+			} else {
+				logger.Logger.Debug().Msgf("%s is set", key)
+			}
+		} else {
+			logger.Logger.Debug().Msgf("%s is optional", key)
+		}
+	}
+
+	if num := len(missingKeys); num > 0 {
+		return errors.New(fmt.Sprintf("%d keys lacked or their values are empty: %s", num, strings.Join(missingKeys, ",")))
+	} else {
+		return nil
+	}
+}

--- a/internal/net/fields.go
+++ b/internal/net/fields.go
@@ -110,12 +110,14 @@ func (f *Form) Serialize() (string, *bytes.Buffer, error) {
 
 			switch field.Kind {
 			case File:
+				logger.Logger.Debug().Msgf("serialize %s as file in from", name)
 				if fw, err := w.CreateFormFile(name, filepath.Base(field.Value)); err != nil {
 					return err
 				} else if _, err = io.Copy(fw, reader); err != nil {
 					return err
 				}
 			case NonFile:
+				logger.Logger.Debug().Msgf("serialize %s as string in from", name)
 				if fw, err := w.CreateFormField(name); err != nil {
 					return err
 				} else if _, err = io.Copy(fw, reader); err != nil {

--- a/internal/net/fields.go
+++ b/internal/net/fields.go
@@ -74,6 +74,10 @@ type Form struct {
 	Fields []ValueField
 }
 
+func (f *Form) Empty() bool {
+	return len(f.Fields) == 0
+}
+
 func (f *Form) Set(field ValueField) {
 	if f.Fields == nil {
 		f.Fields = []ValueField{field}

--- a/internal/net/http_client.go
+++ b/internal/net/http_client.go
@@ -130,25 +130,25 @@ func (c *HttpClient) DoPost(ctx context.Context, paths []string, queries map[str
 	}
 }
 
-func (c *HttpClient) DoPostFileBody(ctx context.Context, paths []string, filePath string) (*HttpResponse, error) {
+func (c *HttpClient) DoPostFileBody(ctx context.Context, paths []string, queries map[string]string, filePath string) (*HttpResponse, error) {
 	if f, err := os.Open(filePath); err != nil {
 		return nil, errors.Wrapf(err, "%s is not found", filePath)
 	} else if b, err := io.ReadAll(f); err != nil {
 		return nil, errors.Wrapf(err, "%s cannot be read", filePath)
 	} else {
 		buffer := bytes.NewBuffer(b)
-		return c.DoPost(ctx, paths, nil, "application/octet-stream", buffer)
+		return c.DoPost(ctx, paths, queries, "application/octet-stream", buffer)
 	}
 }
 
-func (c *HttpClient) DoPostMultipartForm(ctx context.Context, paths []string, form *Form) (*HttpResponse, error) {
+func (c *HttpClient) DoPostMultipartForm(ctx context.Context, paths []string, queries map[string]string, form *Form) (*HttpResponse, error) {
 	contentType, buffer, err := form.Serialize()
 
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to serialize the request form")
 	}
 
-	return c.DoPost(ctx, paths, nil, contentType, buffer)
+	return c.DoPost(ctx, paths, queries, contentType, buffer)
 }
 
 func (c *HttpClient) do(ctx context.Context, paths []string, queries map[string]string, method string, contentType string, requestBody io.Reader) (*HttpResponse, error) {

--- a/internal/net/http_client.go
+++ b/internal/net/http_client.go
@@ -13,6 +13,7 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"strings"
 )
 
 func NewHttpClient(baseUrl string) *HttpClient {
@@ -173,8 +174,8 @@ func (c *HttpClient) do(ctx context.Context, paths []string, queries map[string]
 		return nil, errors.Wrap(err, "failed to build the request")
 	}
 
-	for name, value := range c.headers {
-		request.Header.Set(name, value[0])
+	for name, values := range c.headers {
+		request.Header.Set(name, strings.Join(values, ","))
 	}
 
 	if contentType != "" {

--- a/internal/net/http_client_test.go
+++ b/internal/net/http_client_test.go
@@ -289,7 +289,7 @@ func Test_HttpClient_DoPostMultipartForm(t *testing.T) {
 
 			var resp testResponse
 
-			if r, err := client.DoPostMultipartForm(ctx, c.paths, &c.form); err != nil {
+			if r, err := client.DoPostMultipartForm(ctx, c.paths, nil, &c.form); err != nil {
 				t.Errorf("%s is expected to be success but not: %v", name, err)
 			} else if _, err := r.ParseJson(&resp); err != nil {
 				t.Errorf("%s failed to parse the response: %v", name, err)

--- a/internal/util/urls.go
+++ b/internal/util/urls.go
@@ -1,0 +1,22 @@
+package util
+
+import (
+	"fmt"
+	"strings"
+)
+
+func CutEndpoint(v string) (string, string) {
+	scheme, t, ok := strings.Cut(v, "://")
+
+	if !ok {
+		return "", ""
+	}
+
+	hostname, path, ok := strings.Cut(t, "/")
+
+	if !ok {
+		return fmt.Sprintf("%s://%s", scheme, hostname), ""
+	}
+
+	return fmt.Sprintf("%s://%s", scheme, hostname), path
+}

--- a/internal/util/urls_test.go
+++ b/internal/util/urls_test.go
@@ -1,0 +1,34 @@
+package util
+
+import "testing"
+
+func Test_CutEndpoint(t *testing.T) {
+	cases := map[string]struct {
+		value string
+
+		expectedBaseUrl string
+		expectedPath    string
+	}{
+		"url with path without port":        {value: "http://localhost/path1/path2", expectedBaseUrl: "http://localhost", expectedPath: "path1/path2"},
+		"url with path with port":           {value: "http://localhost:3000/path1/path2", expectedBaseUrl: "http://localhost:3000", expectedPath: "path1/path2"},
+		"url with path with trailing slash": {value: "http://localhost/path1/path2/", expectedBaseUrl: "http://localhost", expectedPath: "path1/path2/"},
+		"url without port":                  {value: "http://localhost", expectedBaseUrl: "http://localhost", expectedPath: ""},
+		"url with port":                     {value: "http://localhost:3000", expectedBaseUrl: "http://localhost:3000", expectedPath: ""},
+		"url with trailing slash":           {value: "http://localhost/", expectedBaseUrl: "http://localhost", expectedPath: ""},
+		"empty":                             {value: "", expectedBaseUrl: "", expectedPath: ""},
+	}
+
+	for name, c := range cases {
+		name, c := name, c
+
+		t.Run(name, func(t *testing.T) {
+			baseUrl, path := CutEndpoint(c.value)
+
+			if baseUrl == c.expectedBaseUrl && path == c.expectedPath {
+				return
+			}
+
+			t.Fatalf("baseUrl = %s, path = %s", baseUrl, path)
+		})
+	}
+}

--- a/main.go
+++ b/main.go
@@ -138,6 +138,7 @@ func main() {
 			command.FirebaseAppDistribution("firebase-app-distribution", []string{"firebase", "fad"}),
 			command.Deploy("deploy", []string{}),
 			command.AddDeploymentConfig("add-deployment", []string{}),
+			command.CustomService("service", []string{}),
 		},
 	}
 

--- a/service/custom_service_provider.go
+++ b/service/custom_service_provider.go
@@ -49,6 +49,11 @@ func (r *CustomServiceDeployRequest) SetHeader(name string, value string) {
 	r.headers[name] = []string{value}
 }
 
+func (r *CustomServiceDeployRequest) HasQueryParam(name string) bool {
+	_, found := r.queries[name]
+	return found
+}
+
 func (r *CustomServiceDeployRequest) SetQueryParam(name string, value string) {
 	r.queries[name] = []string{value}
 }
@@ -88,6 +93,8 @@ func (r *CustomServiceDeployResult) ValueResponse() any {
 func (p *CustomServiceProvider) Deploy(filePath string, builder func(req *CustomServiceDeployRequest)) (*CustomServiceDeployResult, error) {
 	request := &CustomServiceDeployRequest{
 		filePath: filePath,
+		headers:  map[string][]string{},
+		queries:  map[string][]string{},
 	}
 
 	builder(request)

--- a/service/custom_service_provider.go
+++ b/service/custom_service_provider.go
@@ -2,13 +2,12 @@ package service
 
 import (
 	"context"
-	"fmt"
 	"github.com/jmatsu/splitter/internal/config"
 	"github.com/jmatsu/splitter/internal/logger"
 	"github.com/jmatsu/splitter/internal/net"
+	"github.com/jmatsu/splitter/internal/util"
 	"github.com/pkg/errors"
 	"github.com/rs/zerolog"
-	"strings"
 )
 
 var customServiceLogger zerolog.Logger
@@ -18,14 +17,13 @@ func init() {
 }
 
 func NewCustomServiceProvider(ctx context.Context, definition *config.CustomServiceDefinition, conf *config.CustomServiceConfig) *CustomServiceProvider {
-	scheme, t, _ := strings.Cut(definition.Endpoint, "://")
-	hostname, path, _ := strings.Cut(t, "/")
+	baseUrl, path := util.CutEndpoint(definition.Endpoint)
 
 	return &CustomServiceProvider{
 		CustomServiceConfig:     *conf,
 		CustomServiceDefinition: *definition,
 		ctx:                     ctx,
-		client:                  net.NewHttpClient(fmt.Sprintf("%s://%s", scheme, hostname)),
+		client:                  net.NewHttpClient(baseUrl),
 		path:                    path,
 	}
 }

--- a/service/custom_service_provider.go
+++ b/service/custom_service_provider.go
@@ -1,0 +1,38 @@
+package service
+
+import (
+	"context"
+	"fmt"
+	"github.com/jmatsu/splitter/internal/config"
+	"github.com/jmatsu/splitter/internal/logger"
+	"github.com/jmatsu/splitter/internal/net"
+	"github.com/rs/zerolog"
+	"strings"
+)
+
+var customServiceLogger zerolog.Logger
+
+func init() {
+	customServiceLogger = logger.Logger.With().Str("service", "custom").Logger()
+}
+
+func NewCustomServiceProvider(ctx context.Context, definition *config.CustomServiceDefinition, conf *config.CustomServiceConfig) *CustomServiceProvider {
+	scheme, t, _ := strings.Cut(definition.Endpoint, "://")
+	hostname, path, _ := strings.Cut(t, "/")
+
+	return &CustomServiceProvider{
+		CustomServiceConfig:     *conf,
+		CustomServiceDefinition: *definition,
+		ctx:                     ctx,
+		client:                  net.NewHttpClient(fmt.Sprintf("%s://%s", scheme, hostname)),
+		path:                    path,
+	}
+}
+
+type CustomServiceProvider struct {
+	config.CustomServiceConfig
+	config.CustomServiceDefinition
+	ctx    context.Context
+	client *net.HttpClient
+	path   string
+}

--- a/service/custom_service_provider.go
+++ b/service/custom_service_provider.go
@@ -41,7 +41,7 @@ type CustomServiceDeployRequest struct {
 	filePath string
 
 	headers map[string][]string
-	query   map[string]string
+	queries map[string][]string
 	form    net.Form
 }
 
@@ -50,7 +50,11 @@ func (r *CustomServiceDeployRequest) SetHeader(name string, value string) {
 }
 
 func (r *CustomServiceDeployRequest) SetQueryParam(name string, value string) {
-	r.query[name] = value
+	r.queries[name] = []string{value}
+}
+
+func (r *CustomServiceDeployRequest) AddQueryParam(name string, value string) {
+	r.queries[name] = append(r.queries[name], value)
 }
 
 func (r *CustomServiceDeployRequest) SetFormParam(name string, value string) {
@@ -62,7 +66,7 @@ func (r *CustomServiceDeployRequest) NewUploadRequest() *CustomServiceUploadAppR
 		filePath: r.filePath,
 
 		headers: r.headers,
-		queries: r.query,
+		queries: r.queries,
 		form:    r.form,
 	}
 }
@@ -88,7 +92,7 @@ func (p *CustomServiceProvider) Deploy(filePath string, builder func(req *Custom
 
 	builder(request)
 
-	deployGateLogger.Debug().Msgf("the request has been built: %v", *request)
+	customServiceLogger.Debug().Msgf("the request has been built: %v", *request)
 
 	if r, err := p.upload(request.NewUploadRequest()); err != nil {
 		return nil, err

--- a/service/custom_service_upload.go
+++ b/service/custom_service_upload.go
@@ -11,7 +11,7 @@ type CustomServiceUploadAppRequest struct {
 	filePath string
 
 	headers map[string][]string
-	queries map[string]string
+	queries map[string][]string
 	form    net.Form
 }
 
@@ -37,7 +37,7 @@ func (p *CustomServiceProvider) upload(request *CustomServiceUploadAppRequest) (
 		case config.FormParamsAssignFormatPrefix:
 			request.form.Set(net.StringField(name, authToken))
 		case config.QueryAssignFormatPrefix:
-			request.queries[name] = authToken
+			request.queries[name] = []string{authToken}
 		default:
 			panic(fmt.Sprintf("%s is not implemented yet", prefix))
 		}

--- a/service/custom_service_upload.go
+++ b/service/custom_service_upload.go
@@ -1,0 +1,90 @@
+package service
+
+import (
+	"fmt"
+	"github.com/jmatsu/splitter/internal/config"
+	"github.com/jmatsu/splitter/internal/net"
+	"github.com/pkg/errors"
+)
+
+type CustomServiceUploadAppRequest struct {
+	filePath string
+}
+
+type CustomServiceUploadResponse struct {
+	RawResponse *net.HttpResponse `json:"-"`
+}
+
+func (r *CustomServiceUploadResponse) Set(v *net.HttpResponse) {
+	r.RawResponse = v
+}
+
+var _ net.TypedHttpResponse = &CustomServiceUploadResponse{}
+
+func (p *CustomServiceProvider) upload(request *CustomServiceUploadAppRequest) (*CustomServiceUploadResponse, error) {
+	var form *net.Form
+	var queries map[string]string
+
+	client := p.client
+	authToken := fmt.Sprintf(p.CustomServiceDefinition.AuthDefinition.ValueFormat, p.CustomServiceConfig.AuthToken)
+
+	if prefix, name, err := p.CustomServiceDefinition.AuthDefinition.AuthValue(); err != nil {
+		return nil, errors.Wrap(err, "couldn't get an auth")
+	} else {
+		switch prefix {
+		case config.HeadersAssignFormatPrefix:
+			client = p.client.WithHeaders(map[string][]string{
+				name: {authToken},
+			})
+		case config.FormParamsAssignFormatPrefix:
+			form = &net.Form{}
+			form.Set(net.StringField(name, authToken))
+		case config.QueryAssignFormatPrefix:
+			queries[name] = authToken
+		default:
+			panic(fmt.Sprintf("%s is not implemented yet", prefix))
+		}
+	}
+
+	if format, name, err := p.SourceFile(); err != nil {
+		switch format {
+		case config.RequestBodyAssignFormat:
+			if form != nil {
+				return nil, errors.New(fmt.Sprintf("%s is not compatible with form requests", format))
+			}
+
+			// no op
+		case config.FormParamsAssignFormatPrefix:
+			if form == nil {
+				form = &net.Form{}
+			}
+
+			form.Set(net.StringField(name, request.filePath))
+		default:
+			panic(fmt.Sprintf("%s is not implemented yet", format))
+		}
+	}
+
+	var resp *net.HttpResponse
+	var err error
+
+	if form != nil {
+		resp, err = client.DoPostMultipartForm(p.ctx, []string{p.path}, queries, form)
+	} else {
+		resp, err = client.DoPostFileBody(p.ctx, []string{p.path}, queries, request.filePath)
+	}
+
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to upload your app to DeployGate")
+	}
+
+	if resp.Successful() {
+		if v, err := resp.ParseJson(&CustomServiceUploadResponse{}); err != nil {
+			return nil, errors.Wrap(err, "succeeded to upload but something went wrong")
+		} else {
+			return v.(*CustomServiceUploadResponse), nil
+		}
+	} else {
+		return nil, errors.Wrap(resp.Err(), "failed to upload your app to custom service")
+	}
+}

--- a/service/custom_service_upload.go
+++ b/service/custom_service_upload.go
@@ -27,21 +27,11 @@ var _ net.TypedHttpResponse = &CustomServiceUploadResponse{}
 
 func (p *CustomServiceProvider) upload(request *CustomServiceUploadAppRequest) (*CustomServiceUploadResponse, error) {
 	for name, value := range p.DefaultRequestDefinition.Headers {
-		if _, found := request.headers[name]; found {
-			request.headers[name] = append(request.headers[name], value)
-		} else {
-			request.headers[name] = []string{value}
-		}
+		request.headers[name] = append(request.headers[name], value)
 	}
 
 	for name, values := range p.DefaultRequestDefinition.Queries {
-		for _, value := range values {
-			if _, found := request.queries[name]; found {
-				request.queries[name] = append(request.queries[name], value)
-			} else {
-				request.queries[name] = []string{value}
-			}
-		}
+		request.queries[name] = append(request.queries[name], values...)
 	}
 
 	for name, value := range p.DefaultRequestDefinition.FormParams {

--- a/service/custom_service_upload.go
+++ b/service/custom_service_upload.go
@@ -26,6 +26,28 @@ func (r *CustomServiceUploadResponse) Set(v *net.HttpResponse) {
 var _ net.TypedHttpResponse = &CustomServiceUploadResponse{}
 
 func (p *CustomServiceProvider) upload(request *CustomServiceUploadAppRequest) (*CustomServiceUploadResponse, error) {
+	for name, value := range p.DefaultRequestDefinition.Headers {
+		if _, found := request.headers[name]; found {
+			request.headers[name] = append(request.headers[name], value)
+		} else {
+			request.headers[name] = []string{value}
+		}
+	}
+
+	for name, values := range p.DefaultRequestDefinition.Queries {
+		for _, value := range values {
+			if _, found := request.queries[name]; found {
+				request.queries[name] = append(request.queries[name], value)
+			} else {
+				request.queries[name] = []string{value}
+			}
+		}
+	}
+
+	for name, value := range p.DefaultRequestDefinition.FormParams {
+		request.form.Set(net.StringField(name, value))
+	}
+
 	authToken := fmt.Sprintf(p.CustomServiceDefinition.AuthDefinition.ValueFormat, p.CustomServiceConfig.AuthToken)
 
 	if prefix, name, err := p.CustomServiceDefinition.AuthDefinition.AuthValue(); err != nil {
@@ -33,10 +55,13 @@ func (p *CustomServiceProvider) upload(request *CustomServiceUploadAppRequest) (
 	} else {
 		switch prefix {
 		case config.HeadersAssignFormatPrefix:
+			customServiceLogger.Debug().Msgf("set a token to %s header", name)
 			request.headers[name] = []string{authToken}
 		case config.FormParamsAssignFormatPrefix:
+			customServiceLogger.Debug().Msgf("set a token to %s form params", name)
 			request.form.Set(net.StringField(name, authToken))
 		case config.QueryAssignFormatPrefix:
+			customServiceLogger.Debug().Msgf("set a token to %s query params", name)
 			request.queries[name] = []string{authToken}
 		default:
 			panic(fmt.Sprintf("%s is not implemented yet", prefix))
@@ -44,12 +69,16 @@ func (p *CustomServiceProvider) upload(request *CustomServiceUploadAppRequest) (
 	}
 
 	if format, name, err := p.SourceFile(); err != nil {
+		panic(err)
+	} else {
 		switch format {
 		case config.RequestBodyAssignFormat:
 			if !request.form.Empty() {
 				return nil, errors.New(fmt.Sprintf("%s is not compatible with form requests", format))
 			}
+			customServiceLogger.Debug().Msgf("a source file will be a request body itself")
 		case config.FormParamsAssignFormatPrefix:
+			customServiceLogger.Debug().Msgf("set a source file with %s = %s", name, request.filePath)
 			request.form.Set(net.FileField(name, request.filePath))
 		default:
 			panic(fmt.Sprintf("%s is not implemented yet", format))

--- a/service/deploygate_upload.go
+++ b/service/deploygate_upload.go
@@ -112,7 +112,7 @@ func (p *DeployGateProvider) upload(request *DeployGateUploadAppRequest) (*Deplo
 		"Authorization": {fmt.Sprintf("Bearer %s", p.ApiToken)},
 	})
 
-	resp, err := client.DoPostMultipartForm(p.ctx, []string{"api", "users", p.AppOwnerName, "apps"}, request.toForm())
+	resp, err := client.DoPostMultipartForm(p.ctx, []string{"api", "users", p.AppOwnerName, "apps"}, nil, request.toForm())
 
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to upload your app to DeployGate")

--- a/service/firebase_app_distribution_release.go
+++ b/service/firebase_app_distribution_release.go
@@ -77,8 +77,8 @@ func (p *FirebaseAppDistributionProvider) updateReleaseNote(request *firebaseApp
 		return nil, errors.Wrap(err, "cannot marshal the update release request")
 	}
 
-	resp, err := client.DoPatch(p.ctx, []string{path}, map[string]string{
-		"updateMask": "release_notes.text",
+	resp, err := client.DoPatch(p.ctx, []string{path}, map[string][]string{
+		"updateMask": {"release_notes.text"},
 	}, "application/json", bytes2.NewBuffer(bytes))
 
 	if err != nil {

--- a/service/firebase_app_distribution_upload.go
+++ b/service/firebase_app_distribution_upload.go
@@ -36,7 +36,7 @@ func (p *FirebaseAppDistributionProvider) upload(request *FirebaseAppDistributio
 		"X-Goog-Upload-Protocol":  {"raw"},
 	})
 
-	resp, err := client.DoPostFileBody(p.ctx, []string{path}, request.filePath)
+	resp, err := client.DoPostFileBody(p.ctx, []string{path}, nil, request.filePath)
 
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to distribute to Firebase App Distribution")

--- a/splitter.document.yml
+++ b/splitter.document.yml
@@ -62,6 +62,24 @@ deployments: # Array<Map>
         # Optional
         delete-source: bool
 
+    use-custom-service:
+        # set a name defined in services section
+        service: <custom-service-name>
+
+        # An auth token of this service
+        # Required
+        auth-token: string
+
+    any-services: # the following parameters are available for all services
+        # command calls will be executed before the deployment
+        # Optional
+        pre-steps: # [][]string
+            - ["cmd", "arg1", ..., "argN"]
+        # command calls will be executed after the successful deployment
+        # Optional
+        post-steps: # [][]string
+            - ["cmd", "arg1", ..., "argN"]
+
 # Define unsupported services as custom services.
 # This section cannot use variable expansion.
 # Optional

--- a/splitter.document.yml
+++ b/splitter.document.yml
@@ -1,3 +1,5 @@
+# Define configurations that you often reuse in this section
+# Optional
 deployments: # Array<Map>
     # each Mapping must have service key
 
@@ -59,6 +61,45 @@ deployments: # Array<Map>
         # Specify true if you would like to delete the source file later and the behavior looks *move* then.
         # Optional
         delete-source: bool
+
+# Define unsupported services as custom services.
+# This section cannot use variable expansion.
+# Optional
+services: # Array<Map>
+    <custom-service-name>:
+        # the endpoint. e.g. https://..../path/to/endpoint
+        # Required
+        endpoint: string
+
+        # specify how splitter set a source file to
+        # Required
+        #
+        # form_params.<name> : a form request that uses <name> field to upload a source file
+        # request_body : set a source file as binary
+        source-file-format: enum string
+
+        # specify how splitter set a token to
+        # Required
+        auth:
+            # form_params.<name> : a form request that uses <name> field for a token
+            # query_params.<name> : set a named param for a token
+            # headers.<name> : set a named header for a token
+            style-format: "headers.Authorization"
+
+            # the value format of tokens
+            # this value must include exact one %s
+            value-format: "Bearer %s"
+
+        # default values of requests
+        default:
+            headers: # map[string]string
+                <header_name>: header_value
+            form-params: # map[string]string
+                <field_name>: field_value
+            queries: # map[string][]string
+                <query_param>:
+                    - value1
+                    - value2
 
 # The output format (Values: pretty, raw, markdown)
 format-style: enum string

--- a/task/custom_service.go
+++ b/task/custom_service.go
@@ -1,0 +1,27 @@
+package task
+
+import (
+	"context"
+	"github.com/jmatsu/splitter/internal/config"
+	"github.com/jmatsu/splitter/service"
+	"github.com/pkg/errors"
+)
+
+func DeployToCustomService(ctx context.Context, def config.CustomServiceDefinition, conf config.CustomServiceConfig, filePath string, builder func(req *service.CustomServiceDeployRequest)) error {
+	if err := conf.Validate(); err != nil {
+		return errors.Wrap(err, "the built config is invalid")
+	}
+
+	provider := service.NewCustomServiceProvider(ctx, &def, &conf)
+
+	formatter := NewFormatter()
+	formatter.TableBuilder = nil
+
+	if response, err := provider.Deploy(filePath, builder); err != nil {
+		return errors.Wrap(err, "cannot deploy this app")
+	} else if err := formatter.Format(response); err != nil {
+		return errors.Wrap(err, "cannot format the response")
+	}
+
+	return nil
+}

--- a/task/custom_service.go
+++ b/task/custom_service.go
@@ -7,7 +7,7 @@ import (
 	"github.com/pkg/errors"
 )
 
-func DeployToCustomService(ctx context.Context, def config.CustomServiceDefinition, conf config.CustomServiceConfig, filePath string, builder func(req *service.CustomServiceDeployRequest)) error {
+func DeployToCustomService(ctx context.Context, def config.CustomServiceDefinition, conf config.CustomServiceConfig, filePath string, builder func(req *service.CustomServiceDeployRequest) error) error {
 	if err := conf.Validate(); err != nil {
 		return errors.Wrap(err, "the built config is invalid")
 	}

--- a/task/deploygate.go
+++ b/task/deploygate.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 )
 
-func DeployToDeployGate(ctx context.Context, conf config.DeployGateConfig, filePath string, builder func(req *service.DeployGateDeployRequest)) error {
+func DeployToDeployGate(ctx context.Context, conf config.DeployGateConfig, filePath string, builder func(req *service.DeployGateDeployRequest) error) error {
 	if err := conf.Validate(); err != nil {
 		return errors.Wrap(err, "the built config is invalid")
 	}

--- a/task/firebase_app_distribution.go
+++ b/task/firebase_app_distribution.go
@@ -9,7 +9,7 @@ import (
 	"github.com/pkg/errors"
 )
 
-func DeployToFirebaseAppDistribution(ctx context.Context, conf config.FirebaseAppDistributionConfig, filePath string, builder func(req *service.FirebaseAppDistributionDeployRequest)) error {
+func DeployToFirebaseAppDistribution(ctx context.Context, conf config.FirebaseAppDistributionConfig, filePath string, builder func(req *service.FirebaseAppDistributionDeployRequest) error) error {
 	if err := conf.Validate(); err != nil {
 		return errors.Wrap(err, "the built config is invalid")
 	}


### PR DESCRIPTION
#25 

```text
USAGE:
   splitter service [command options] [arguments...]

OPTIONS:
   --source-path value, -f value                A path to an app file.
   --auth-token value, -t value                 The auth token to use for this distribution.
   --name value, -n value                       A service name in the config file.
   --header value [ --header value ]            Append <key>=<value> to headers
   --query-param value [ --query-param value ]  Append <key>=<value> to query parameters
   --form-param value [ --form-param value ]    Append <key>=<value> to form parameters
```

```yaml
services:
    <custom-service-name>:
        endpoint: http://example.com
        source-file-format: request_body
        auth:
            style-format: "headers.Authorization"
            value-format: "Bearer %s"
```